### PR TITLE
Use project/relman prefix for artifacts

### DIFF
--- a/taskcluster-hook.json
+++ b/taskcluster-hook.json
@@ -28,7 +28,7 @@
         },
         "payload": {
             "artifacts": {
-                "private/bugzilla-dashboard": {
+                "project/relman/bugzilla-dashboard": {
                     "path": "/output",
                     "type": "directory"
                 }


### PR DESCRIPTION
Because every Mozilla employee now has the scope for that prefix: https://bugzilla.mozilla.org/show_bug.cgi?id=1598250